### PR TITLE
Add HLSL kernel-side packed structures, packed structure loaders, packed field accessors, and field unpackers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /build
+.idea

--- a/piet-metal-derive/src/lib.rs
+++ b/piet-metal-derive/src/lib.rs
@@ -286,7 +286,7 @@ fn hlsl_generate_readers_accessors_and_unpackers(
                                 num_uints_required_for_storage,
                                 package_fieldname,
                                 hlsl_type,
-                                num_uints_required_for_storage,
+                                unpacked_size,
                             )
                                 .unwrap();
 

--- a/piet-metal-derive/src/lib.rs
+++ b/piet-metal-derive/src/lib.rs
@@ -279,7 +279,7 @@ fn hlsl_generate_readers_accessors_and_unpackers(
                                 );
                             write!(
                                 unpacker,
-                                "uint{} {}_unpack_{}(uint{} {}) {{\n    {}{} result;\n\n",
+                                "inline uint{} {}_unpack_{}(uint{} {}) {{\n    {}{} result;\n\n",
                                 unpacked_size,
                                 name,
                                 unpacked_fieldname,
@@ -629,7 +629,7 @@ impl GpuTypeDef {
                 write!(r, "}};\n").unwrap();
                 write!(
                     r,
-                    "uint {}_tag(const device char *buf, {} ref) {{\n",
+                    "inline uint {}_tag(const device char *buf, {} ref) {{\n",
                     en.name, rn
                 )
                     .unwrap();

--- a/piet-metal-derive/src/lib.rs
+++ b/piet-metal-derive/src/lib.rs
@@ -629,7 +629,7 @@ impl GpuTypeDef {
                 write!(r, "}};\n").unwrap();
                 write!(
                     r,
-                    "inline uint {}_tag(const device char *buf, {} ref) {{\n",
+                    "uint {}_tag(const device char *buf, {} ref) {{\n",
                     en.name, rn
                 )
                     .unwrap();
@@ -959,7 +959,7 @@ impl GpuTypeDef {
                 write!(r, "}};\n").unwrap();
                 write!(
                     r,
-                    "uint {}_tag(ByteAddressBuffer buf, {} ref) {{\n",
+                    "inline uint {}_tag(ByteAddressBuffer buf, {} ref) {{\n",
                     en.name, rn
                 )
                     .unwrap();
@@ -1114,8 +1114,8 @@ pub fn piet_hlsl(input: TokenStream) -> TokenStream {
     let gen_hlsl_fn = format_ident!("gen_hlsl_{}", input.ident);
     let result = module.to_hlsl();
     let expanded = quote! {
-        fn #gen_hlsl_fn() {
-            println!("{}", #result);
+        fn #gen_hlsl_fn() -> String{
+            String::from(#result)
         }
     };
     expanded.into()

--- a/piet-metal-derive/src/lib.rs
+++ b/piet-metal-derive/src/lib.rs
@@ -1112,3 +1112,13 @@ pub fn piet_hlsl(input: TokenStream) -> TokenStream {
     };
     expanded.into()
 }
+
+impl Parse for Items {
+    fn parse(input: ParseStream) -> Result<Self, syn::Error> {
+        let mut items = Vec::new();
+        while !input.is_empty() {
+            items.push(input.parse()?)
+        }
+        Ok(Items(items))
+    }
+}


### PR DESCRIPTION
These additions allow the generation of kernel-side structs in HLSL. Since the smallest types HLSL supports are 32 bit wide, it is necessary to take into account packing of 8 bit, or 16 bit values into a 32 bit wide integer, in order to use memory as efficiently as possible. Hence, kernel-side HLSL structs are "packed" versions of specified structs. Helper functions to load entire structs, or specific fields, from byte streams are also generated. Finally, unpacking functions to extract particular fields from packed fields are generated.